### PR TITLE
fix indentation error in v2ray-http-upgrade

### DIFF
--- a/docs/config/proxies/vless.md
+++ b/docs/config/proxies/vless.md
@@ -99,5 +99,5 @@
     path: "/"
     headers:
       Host: example.com
-      # v2ray-http-upgrade: false
+    # v2ray-http-upgrade: false
 ```


### PR DESCRIPTION
`v2ray-http-upgrade` 应该和 `headers` 平级

见 MetaCubeX/mihomo#886