### PR TITLE
fix logging command for systemd logging in documents

### DIFF
--- a/docs/startup/service/index.md
+++ b/docs/startup/service/index.md
@@ -75,9 +75,9 @@ systemctl status mihomo
 使用以下命令检查 mihomo 的运行日志:
 
 ```shell
-journalctl -u meta -o cat -e
+journalctl -u mihomo -o cat -e
 ```
 或
 ```shell
-journalctl -u meta -o cat -f
+journalctl -u mihomo -o cat -f
 ```


### PR DESCRIPTION
the command was intended for older "clash-meta" and wasn't updated for mihomo usage.