### PR TITLE
change clash to mihomo,  now, chinese document is consistent with the english document.

### DIFF
--- a/docs/api/index.en.md
+++ b/docs/api/index.en.md
@@ -272,4 +272,4 @@ go tool pprof -http=:8080 http://127.0.0.1:xxxx/debug/pprof/allocs
 
 ##### Submit Output Report
 
-Access `http://${controller-api}/debug/pprof/heap?raw=true` in a browser to download this file, and upload it to [issues](https://github.com/MetaCubeX/Clash.Meta/issues) to report any problems you encounter.
+Access `http://${controller-api}/debug/pprof/heap?raw=true` in a browser to download this file, and upload it to [issues](https://github.com/MetaCubeX/mihomo/issues) to report any problems you encounter.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -272,4 +272,4 @@ go tool pprof -http=:8080 http://127.0.0.1:xxxx/debug/pprof/allocs
 
 ##### 提交输出报告
 
-浏览器访问 `http://${controller-api}/debug/pprof/heap?raw=true` 即可下载这个文件，通过上传到 [issues](https://github.com/MetaCubeX/Clash.Meta/issues) 提交你遇到的问题。
+浏览器访问 `http://${controller-api}/debug/pprof/heap?raw=true` 即可下载这个文件，通过上传到 [issues](https://github.com/MetaCubeX/mihomo/issues) 提交你遇到的问题。

--- a/docs/startup/service/index.md
+++ b/docs/startup/service/index.md
@@ -12,7 +12,7 @@ hide:
 
 - 以守护进程的方式，运行 mihomo。
 
-使用以下命令将 Clash 二进制文件复制到 /usr/local/bin, 配置文件复制到 /etc/mihomo:
+使用以下命令将 mihomo 二进制文件复制到 /usr/local/bin, 配置文件复制到 /etc/mihomo:
 
 ```shell
 cp mihomo /usr/local/bin


### PR DESCRIPTION
发现了英文文档和中文文档中有一处不一样

英文文档中是
```
Use the following commands to copy the Mihomo binary file to /usr/local/bin and the configuration file to /etc/mihomo:
```
所以我把中文文档改成和英文统一了

以及issue的连接改成了当前项目的url，不需要再经过301了