### PR TITLE
fix(FAQ): update program name from Clash.meta to Mihomo

### DIFF
--- a/docs/startup/faq.en.md
+++ b/docs/startup/faq.en.md
@@ -13,7 +13,7 @@ The Alpha branch is the latest commit branch, while the Meta branch merges the c
 
 In`release`, the filename of each package includes several pieces of information, including:
 
-* Program name (`clash.meta`)
+* Program name (`mihomo`)
 * Operating system (e.g., `android`, `darwin`, `freebsd`, `linux`, `windows`, etc.)
 * Architecture (e.g., `386`, `amd64`, `arm32v7`, `arm64`, etc.)
 * Compilation method:

--- a/docs/startup/faq.md
+++ b/docs/startup/faq.md
@@ -13,7 +13,7 @@ alpha 分支为最新提交分支，meta 分支每隔一段时间合并 alpha �
 
 release 中，包的文件名中包含了多个信息，包括
 
-* 程序名称（clash.meta）
+* 程序名称 (`mihomo`)
 * 操作系统（如 android、darwin、freebsd、linux、windows 等）
 * 架构（如 386、amd64、arm32v7、arm64 等）
 * 编译方式


### PR DESCRIPTION
Fixed the FAQ section to reflect the new program name for consistency.