### PR TITLE
fix: use quotation marks to enclose '*' to prevent errors

### DIFF
--- a/docs/config/general.en.md
+++ b/docs/config/general.en.md
@@ -139,7 +139,7 @@ API CORS Header Configuration
 ```{.yaml linenums="1"}
 external-controller-cors:
   allow-origins:
-    - *
+    - '*'
   allow-private-network: true
 ```
 

--- a/docs/config/general.md
+++ b/docs/config/general.md
@@ -141,7 +141,7 @@ API CORS 标头配置
 ```{.yaml linenums="1"}
 external-controller-cors:
   allow-origins:
-    - *
+    - '*'
   allow-private-network: true
 ```
 


### PR DESCRIPTION
When there are no quotes surrounding * in the yaml file, mihomo will report an error
![image](https://github.com/user-attachments/assets/07a7bece-559f-4093-8393-b0e3ccc0b8d7)
