### PR TITLE
Add ClashFest and SlothClash to third-party client list.

### DIFF
--- a/docs/startup/client/client.en.md
+++ b/docs/startup/client/client.en.md
@@ -27,6 +27,7 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[Bettbox](https://github.com/appshubcc/Bettbox)|Maintained |
 |[GoclashZ](https://github.com/Zzz-IT/GoclashZ)|Maintained |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|Maintained |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|Maintained |
 
 ## MacOS
 
@@ -48,6 +49,7 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[Bettbox](https://github.com/appshubcc/Bettbox)|Maintained |
 |[ClashBar](https://github.com/Sitoi/ClashBar)|Maintained |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|Maintained |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|Maintained |
 
 ## Linux
 
@@ -69,6 +71,7 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[ShellCrash](https://github.com/juewuy/ShellCrash)|Maintained |
 |[Bettbox](https://github.com/appshubcc/Bettbox)|Maintained |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|Maintained |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|Maintained |
 
 ## Android
 
@@ -82,6 +85,7 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[FlClashX](https://github.com/pluralplay/FlClashX)|Maintained |
 |[clash-xiaoy](https://github.com/aimy1/clash-xiaoy)|Maintained |
 |[MonadBox](https://github.com/MonadBoxLab/MonadBox)|Maintained |
+|[ClashFest](https://github.com/Nemu-x/ClashFest)|Maintained |
 
 ## iOS
 

--- a/docs/startup/client/client.md
+++ b/docs/startup/client/client.md
@@ -27,6 +27,7 @@
 |[Bettbox](https://github.com/appshubcc/Bettbox)|维护中 |
 |[GoclashZ](https://github.com/Zzz-IT/GoclashZ)|维护中 |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|维护中 |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|维护中 |
 
 ## MacOS
 
@@ -49,6 +50,7 @@
 |[ClashBar](https://github.com/Sitoi/ClashBar)|维护中 |
 |[CatBar](https://github.com/QuentinHsu/cat-bar)|维护中 |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|维护中 |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|维护中 |
 
 ## Linux
 
@@ -70,6 +72,7 @@
 |[ShellCrash](https://github.com/juewuy/ShellCrash)|维护中 |
 |[Bettbox](https://github.com/appshubcc/Bettbox)|维护中 |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|维护中 |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|维护中 |
 
 ## Android
 
@@ -83,6 +86,7 @@
 |[FlClashX](https://github.com/pluralplay/FlClashX)|维护中 |
 |[clash-xiaoy](https://github.com/aimy1/clash-xiaoy)|维护中 |
 |[MonadBox](https://github.com/MonadBoxLab/MonadBox)|维护中 |
+|[ClashFest](https://github.com/Nemu-x/ClashFest)|维护中 |
 
 ## iOS
 

--- a/docs/startup/client/client.ru.md
+++ b/docs/startup/client/client.ru.md
@@ -27,6 +27,7 @@
 |[Bettbox](https://github.com/appshubcc/Bettbox)|поддерживается |
 |[GoclashZ](https://github.com/Zzz-IT/GoclashZ)|поддерживается |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|поддерживается |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|поддерживается |
 
 ## MacOS
 
@@ -48,6 +49,7 @@
 |[Bettbox](https://github.com/appshubcc/Bettbox)|поддерживается |
 |[ClashBar](https://github.com/Sitoi/ClashBar)|поддерживается |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|поддерживается |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|поддерживается |
 
 ## Linux
 
@@ -69,6 +71,7 @@
 |[ShellCrash](https://github.com/juewuy/ShellCrash)|поддерживается |
 |[Bettbox](https://github.com/appshubcc/Bettbox)|поддерживается |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|поддерживается |
+|[SlothClash](https://github.com/Nemu-x/SlothClash)|поддерживается |
 
 ## Android
 
@@ -82,6 +85,7 @@
 |[FlClashX](https://github.com/pluralplay/FlClashX)|поддерживается |
 |[clash-xiaoy](https://github.com/aimy1/clash-xiaoy)|поддерживается |
 |[MonadBox](https://github.com/MonadBoxLab/MonadBox)|поддерживается |
+|[ClashFest](https://github.com/Nemu-x/ClashFest)|поддерживается |
 
 ## iOS
 


### PR DESCRIPTION
## Summary
- Add [ClashFest](https://github.com/Nemu-x/ClashFest) (Android) to the third-party client list
- Add [SlothClash](https://github.com/Nemu-x/SlothClash) (Windows, macOS, Linux) to the third-party client list
- Updated zh, en, and ru locale pages