### PR TITLE
Add `mux-option` in listeners

### DIFF
--- a/docs/config/inbound/listeners/hysteria2.md
+++ b/docs/config/inbound/listeners/hysteria2.md
@@ -43,6 +43,12 @@ listeners:
   #   madSJjYQIf9o1N5GXjkW4DEEeb17qMxHdwMdNnwADAABAAEAAQACAAEAAwAIdGVz
   #   dC5jb20AAA==
   #   -----END ECH KEYS-----
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```
 
 ## [通用字段](./index.md)

--- a/docs/config/inbound/listeners/hysteria2.ru.md
+++ b/docs/config/inbound/listeners/hysteria2.ru.md
@@ -43,6 +43,12 @@ listeners:
   #   madSJjYQIf9o1N5GXjkW4DEEeb17qMxHdwMdNnwADAABAAEAAQACAAEAAwAIdGVz
   #   dC5jb20AAA==
   #   -----END ECH KEYS-----
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ```
 
 ## [Общие поля](./index.md)

--- a/docs/config/inbound/listeners/ss.md
+++ b/docs/config/inbound/listeners/ss.md
@@ -44,6 +44,12 @@ listeners:
   #   framesize: 8192 # smux max frame size
   #   streambuf: 2097152 # per stream receive buffer in bytes, smux v2+
   #   keepalive: 10 # seconds between heartbeats
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```
 
 ## [通用字段](./index.md)

--- a/docs/config/inbound/listeners/ss.ru.md
+++ b/docs/config/inbound/listeners/ss.ru.md
@@ -44,6 +44,12 @@ listeners:
   #   framesize: 8192 # smux max frame size
   #   streambuf: 2097152 # per stream receive buffer in bytes, smux v2+
   #   keepalive: 10 # seconds between heartbeats
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ```
 
 ## [Общие поля](./index.md)

--- a/docs/config/inbound/listeners/sudoku.md
+++ b/docs/config/inbound/listeners/sudoku.md
@@ -23,6 +23,12 @@ listeners:
   # 可选：当启用 HTTPMask 且识别到“像 HTTP 但不符合 tunnel/auth”的请求时，将原始字节透传给 fallback（常用于与其他服务共端口）：
   # fallback: "127.0.0.1:80"
   disable-http-mask: false # 可选：禁用 http 掩码/隧道（默认为 false）
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 
 ```
 

--- a/docs/config/inbound/listeners/sudoku.ru.md
+++ b/docs/config/inbound/listeners/sudoku.ru.md
@@ -18,6 +18,12 @@ listeners:
   disable-http-mask: false # Опционально: отключить HTTP маску/туннель (по умолчанию false)
   # http-mask-mode: legacy # Опционально: legacy (по умолчанию), stream, poll, auto; stream/poll/auto поддерживают работу через CDN/прокси
   # path-root: "" # Опционально: префикс пути первого уровня для HTTP туннеля (должен совпадать на обеих сторонах), например "aabbcc" => /aabbcc/session, /aabbcc/stream, /aabbcc/api/v1/upload
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 
 ```
 

--- a/docs/config/inbound/listeners/trojan.md
+++ b/docs/config/inbound/listeners/trojan.md
@@ -50,4 +50,10 @@ listeners:
   #   password: "example"
   ### 注意，对于trojan listener, 如果 "allow-insecure" 不为 true, 至少需要填写 “certificate和private-key” 或 “reality-config” 或 “ss-option” 的其中一项 ###
   # allow-insecure: false # 是否允许不开启tls加密（注意：仅用于有 nginx, caddy 前置的情况）
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```

--- a/docs/config/inbound/listeners/trojan.ru.md
+++ b/docs/config/inbound/listeners/trojan.ru.md
@@ -50,4 +50,10 @@ listeners:
   #   password: "example"
   ### Обратите внимание, что для троянских программ, если параметр "allow-insecure" не равен true, необходимо заполнить хотя бы одно из следующих полей: "certificate and private-key", "reality-config" или "ss-option". ###
   # allow-insecure: false # Разрешить ли отключение шифрования TLS (Примечание: только в случаях, когда nginx или caddy установлены предварительно)
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ``` 

--- a/docs/config/inbound/listeners/tuic-v4.md
+++ b/docs/config/inbound/listeners/tuic-v4.md
@@ -27,4 +27,10 @@ listeners:
   alpn:
     - h3
   max-udp-relay-packet-size: 1500
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```

--- a/docs/config/inbound/listeners/tuic-v4.ru.md
+++ b/docs/config/inbound/listeners/tuic-v4.ru.md
@@ -27,4 +27,10 @@ listeners:
   alpn:
     - h3
   max-udp-relay-packet-size: 1500
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ``` 

--- a/docs/config/inbound/listeners/tuic-v5.md
+++ b/docs/config/inbound/listeners/tuic-v5.md
@@ -28,4 +28,10 @@ listeners:
   alpn:
     - h3
   max-udp-relay-packet-size: 1500
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```

--- a/docs/config/inbound/listeners/tuic-v5.ru.md
+++ b/docs/config/inbound/listeners/tuic-v5.ru.md
@@ -28,4 +28,10 @@ listeners:
   alpn:
     - h3
   max-udp-relay-packet-size: 1500
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ``` 

--- a/docs/config/inbound/listeners/vless.md
+++ b/docs/config/inbound/listeners/vless.md
@@ -82,4 +82,10 @@ listeners:
       burst-bytes-per-sec: 0 # 突发速率（字节/秒），大于 bytesPerSec 时生效
   ### 注意，对于vless listener, 如果 "allow-insecure" 不为 true, 至少需要填写 “certificate和private-key” 或 “reality-config” 或 “decryption” 的其中一项 ###
   # allow-insecure: false # 是否允许不开启tls加密（注意：仅用于有 nginx, caddy 前置的情况）
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```

--- a/docs/config/inbound/listeners/vless.ru.md
+++ b/docs/config/inbound/listeners/vless.ru.md
@@ -82,4 +82,10 @@ listeners:
       burst-bytes-per-sec: 0 # пиковая скорость (байт/сек), действует когда больше bytesPerSec
   ### Обратите внимание, что для слушателей Vless, если параметр "allow-insecure" не равен true, необходимо заполнить хотя бы одно из следующих полей: "certificate and private-key", "reality-config" или "decryption". ###
   # allow-insecure: false # Разрешить ли отключение шифрования TLS (Примечание: только в случаях, когда nginx или caddy установлены предварительно)
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ``` 

--- a/docs/config/inbound/listeners/vmess.md
+++ b/docs/config/inbound/listeners/vmess.md
@@ -45,4 +45,10 @@ listeners:
   #     after-bytes: 0 # 传输指定字节后开始限速
   #     bytes-per-sec: 0 # 基准速率（字节/秒）
   #     burst-bytes-per-sec: 0 # 突发速率（字节/秒），大于 bytesPerSec 时生效
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # 默认 Mbps
+  #     down: 1000
 ```

--- a/docs/config/inbound/listeners/vmess.ru.md
+++ b/docs/config/inbound/listeners/vmess.ru.md
@@ -45,4 +45,10 @@ listeners:
   #     after-bytes: 0 # начать ограничение скорости после передачи указанного количества байт
   #     bytes-per-sec: 0 # базовая скорость (байт/сек)
   #     burst-bytes-per-sec: 0 # пиковая скорость (байт/сек), действует когда больше bytesPerSec
+  # mux-option:
+  #   padding: true
+  #   brutal:
+  #     enabled: true
+  #     up: 1000 # по умолчанию в Mbps
+  #     down: 1000
 ``` 


### PR DESCRIPTION
Previously, there wasn't mention of the `mux-option` for the server in the docs.
I ran `grep` to find out which listeners accept this parameter. I was a bit confused that hysteria2 accepts it, but I decided to add it to the docs anyway, since it does. But maybe I should have added it only for certain protocols...