### PR TITLE
docs(api): add response fields for all API endpoints

### DIFF
--- a/docs/api/index.en.md
+++ b/docs/api/index.en.md
@@ -44,7 +44,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 ### `/traffic`
 
 !!! info ""
-    Retrieve real-time traffic, measured in kbps
+    Retrieve real-time traffic; `up`/`down` are in bytes/s, `upTotal`/`downTotal` are in bytes
 
 - Request method: `GET` / `WS`
 - Response fields (pushed once per second):
@@ -58,7 +58,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 ### `/memory`
 
 !!! info ""
-    Retrieve real-time memory usage, measured in kb
+    Retrieve real-time memory usage, measured in bytes
 
 - Request method: `GET` / `WS`
 - Response fields (pushed once per second):

--- a/docs/api/index.en.md
+++ b/docs/api/index.en.md
@@ -30,6 +30,14 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 - Request method: `GET` / `WS`
 - Optional parameter: `?level=log_level`, where `log_level` can be `info`, `warning`, `error`, `debug`
 - Optional parameter: `?format=structured`, when present outputs structured logs (with `time`, `level`, `message`, `fields` fields)
+- Response fields (standard mode, one JSON per line):
+    - `type`: log level — `info` / `warning` / `error` / `debug`
+    - `payload`: log message content
+- Response fields (structured mode `?format=structured`):
+    - `time`: time string in `HH:MM:SS` format
+    - `level`: log level
+    - `message`: log message content
+    - `fields`: array of additional fields
 
 ## Traffic Information
 
@@ -39,6 +47,11 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve real-time traffic, measured in kbps
 
 - Request method: `GET` / `WS`
+- Response fields (pushed once per second):
+    - `up`: current upload rate (bytes/s)
+    - `down`: current download rate (bytes/s)
+    - `upTotal`: cumulative uploaded bytes
+    - `downTotal`: cumulative downloaded bytes
 
 ## Memory Information
 
@@ -48,6 +61,9 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve real-time memory usage, measured in kb
 
 - Request method: `GET` / `WS`
+- Response fields (pushed once per second):
+    - `inuse`: current memory in use (bytes)
+    - `oslimit`: OS memory limit (bytes, always `0`)
 
 ## Version Information
 
@@ -57,6 +73,9 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve the Clash version
 
 - Request method: `GET`
+- Response fields:
+    - `meta`: whether this is a Meta build (`true` / `false`)
+    - `version`: version string
 
 ## Cache
 
@@ -66,6 +85,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Clear the fake IP cache
 
 - Request method: `POST`
+- Response: none (HTTP 204)
 
 ### `/cache/dns/flush`
 
@@ -73,6 +93,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Clear the DNS cache
 
 - Request method: `POST`
+- Response: none (HTTP 204)
 
 ## Running Configuration
 
@@ -82,18 +103,21 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve basic configuration
 
 - Request method: `GET`
+- Response fields: JSON object of the current running configuration, including `port`, `socks-port`, `mixed-port`, `mode`, `log-level`, `allow-lan`, `ipv6`, `tun`, and other fields
 
 !!! info ""
     Reload basic configuration
 
 - Request method: `PUT`
 - Parameter: `?force=true`
+- Response: none (HTTP 204)
 
 !!! info ""
     Update basic configuration
 
 - Request method: `PATCH`
 - Data: `'{"mixed-port": 7890}'`
+- Response: none (HTTP 204)
 
 ### `/configs/geo`
 
@@ -102,6 +126,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `POST`
 - Data: `'{"path": "", "payload": ""}'`
+- Response: none (HTTP 204)
 
 ### `/restart`
 
@@ -110,6 +135,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `POST`
 - Data: `'{"path": "", "payload": ""}'`
+- Response: none (HTTP 204)
 
 ## Updates
 
@@ -121,6 +147,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 - Request method: `POST`
 - Optional parameters: `?channel=xxx` specifies the update channel, `?force=true` forces the update
 - Data: `'{"path": "", "payload": ""}'`
+- Response fields:
+    - `status`: fixed value `"ok"`
 
 ### `/upgrade/ui`
 
@@ -128,6 +156,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Update the panel; [external-ui](../config/general.md#external-user-interface) must be set
 
 - Request method: `POST`
+- Response fields:
+    - `status`: fixed value `"ok"`
 
 ### `/upgrade/geo`
 
@@ -136,6 +166,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `POST`
 - Data: `'{"path": "", "payload": ""}'`
+- Response: none (HTTP 204)
 
 ## Policy Groups
 
@@ -145,6 +176,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve policy group information
 
 - Request method: `GET`
+- Response fields:
+    - `proxies`: array of policy group objects, each in the same format as `/proxies/proxies_name`
 
 ### `/group/group_name`
 
@@ -152,6 +185,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve specific policy group information
 
 - Request method: `GET`
+- Response fields: policy group object, same format as `/proxies/proxies_name`
 
 ### `/group/group_name/delay`
 
@@ -161,6 +195,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 - Request method: `GET`
 - Parameter: `?url=xxx&timeout=5000`
 - Optional parameter: `?expected=xxx`, the expected HTTP response status code, supports ranges (e.g. `200/204`, `200-299`)
+- Response fields: JSON object mapping node names to their latency in milliseconds (`uint16`), e.g. `{"Node A": 120, "Node B": 350}`
 
 ## Proxies
 
@@ -170,6 +205,23 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve proxy information
 
 - Request method: `GET`
+- Response fields:
+    - `proxies`: object keyed by proxy name; each proxy contains:
+        - `name`: proxy name
+        - `type`: proxy type (e.g. `Shadowsocks`, `VMess`, `DIRECT`, `Selector`, etc.)
+        - `udp`: whether UDP is supported
+        - `uot`: whether UDP over TCP is supported
+        - `xudp`: whether XUDP is supported
+        - `tfo`: whether TCP Fast Open is enabled
+        - `mptcp`: whether MPTCP is enabled
+        - `smux`: whether stream multiplexing is enabled
+        - `alive`: whether the proxy is currently alive
+        - `history`: array of delay history entries, each with `time` and `delay` (ms)
+        - `extra`: extra delay histories grouped by test URL
+        - `interface`: bound network interface name
+        - `routing-mark`: routing mark value
+        - `provider-name`: name of the proxy provider this proxy belongs to
+        - `dialer-proxy`: underlying dialer proxy name
 
 ### `/proxies/proxies_name`
 
@@ -177,17 +229,20 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve specific proxy information
 
 - Request method: `GET`
+- Response fields: proxy object, same fields as a single entry under `/proxies`
 
 !!! info ""
     Select a specific proxy
 
 - Request method: `PUT`
 - Data: `'{"name":"Japan"}'`
+- Response: none (HTTP 204)
 
 !!! info ""
     Clear the fixed selection of the proxy/policy group (except for the `Selector` type)
 
 - Request method: `DELETE`
+- Response: none (HTTP 204)
 
 ### `/proxies/proxies_name/delay`
 
@@ -197,6 +252,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 - Request method: `GET`
 - Parameter: `?url=xxx&timeout=5000`
 - Optional parameter: `?expected=xxx`, the expected HTTP response status code, supports ranges (e.g. `200/204`, `200-299`)
+- Response fields:
+    - `delay`: measured latency in milliseconds (`uint16`)
 
 ## Proxy Sets
 
@@ -206,6 +263,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve all information for all proxy sets
 
 - Request method: `GET`
+- Response fields:
+    - `providers`: object keyed by provider name, each containing provider metadata and its proxy list
 
 ### `/providers/proxies/providers_name`
 
@@ -213,11 +272,13 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve information for a specific proxy set
 
 - Request method: `GET`
+- Response fields: proxy provider object including configuration metadata and a `proxies` list
 
 !!! info ""
     Update the proxy set
 
 - Request method: `PUT`
+- Response: none (HTTP 204)
 
 ### `/providers/proxies/providers_name/healthcheck`
 
@@ -225,6 +286,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Trigger a health check for a specific proxy set
 
 - Request method: `GET`
+- Response: none (HTTP 204)
 
 ### `/providers/proxies/providers_name/proxies_name`
 
@@ -232,6 +294,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve information for a specified proxy within the proxy set
 
 - Request method: `GET`
+- Response fields: proxy object, same fields as `/proxies/proxies_name`
 
 ### `/providers/proxies/providers_name/proxies_name/healthcheck`
 
@@ -240,6 +303,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `GET`
 - Parameter: `?url=xxx&timeout=5000`
+- Response fields:
+    - `delay`: measured latency in milliseconds (`uint16`)
 
 ## Rules
 
@@ -249,6 +314,19 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve rule information
 
 - Request method: `GET`
+- Response fields:
+    - `rules`: array of rule objects, each containing:
+        - `index`: rule index (0-based)
+        - `type`: rule type (e.g. `DOMAIN`, `IP-CIDR`, `GEOIP`, etc.)
+        - `payload`: rule match content
+        - `proxy`: target proxy or policy group name
+        - `size`: number of entries in the rule set (only valid for `GEOIP` / `GEOSITE`, `-1` otherwise)
+        - `extra` (optional, when present includes):
+            - `disabled`: whether the rule is disabled
+            - `hitCount`: number of times the rule was matched
+            - `hitAt`: timestamp of the last match
+            - `missCount`: number of times the rule was not matched
+            - `missAt`: timestamp of the last miss
 
 ### `/rules/disable`
 
@@ -257,6 +335,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `PATCH`
 - Data: `'{"0": false,"1": true}'`
+- Response: none (HTTP 204)
 
 ## Rule Sets
 
@@ -266,6 +345,8 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve all information for all rule sets
 
 - Request method: `GET`
+- Response fields:
+    - `providers`: object keyed by rule provider name
 
 ### `/providers/rules/providers_name`
 
@@ -273,6 +354,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Update the rule set
 
 - Request method: `PUT`
+- Response: none (HTTP 204)
 
 ## Connections
 
@@ -283,11 +365,26 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `GET` / `WS`
 - Optional parameter: `?interval=milliseconds`, where `milliseconds` is the refresh interval, default value is 1000 milliseconds
+- Response fields:
+    - `downloadTotal`: cumulative downloaded bytes
+    - `uploadTotal`: cumulative uploaded bytes
+    - `memory`: current memory usage (bytes)
+    - `connections`: array of active connection objects, each containing:
+        - `id`: unique connection ID
+        - `metadata`: connection metadata (source/destination address, protocol, process name, etc.)
+        - `upload`: bytes uploaded on this connection
+        - `download`: bytes downloaded on this connection
+        - `start`: connection start time
+        - `chains`: proxy chain array
+        - `providerChains`: provider proxy chain array
+        - `rule`: matched rule type
+        - `rulePayload`: matched rule content
 
 !!! info ""
     Close all connections
 
 - Request method: `DELETE`
+- Response: none (HTTP 204)
 
 ### `/connections/:id`
 
@@ -295,6 +392,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Close a specific connection
 
 - Request method: `DELETE`
+- Response: none (HTTP 204)
 
 ## Domain Query
 
@@ -305,6 +403,17 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `GET`
 - Parameter: `?name=example.com&type=A`
+- Response fields:
+    - `Status`: DNS response code (Rcode)
+    - `Question`: array of query questions
+    - `TC`: whether the response is truncated
+    - `RD`: recursion desired flag
+    - `RA`: recursion available flag
+    - `AD`: authenticated data flag
+    - `CD`: checking disabled flag
+    - `Answer` (optional): array of answer records, each with `name`, `type`, `TTL`, `data`
+    - `Authority` (optional): array of authority records, same format as `Answer`
+    - `Additional` (optional): array of additional records, same format as `Answer`
 
 ## Storage
 
@@ -314,17 +423,20 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve the storage value for the specified key, returns `null` if it does not exist
 
 - Request method: `GET`
+- Response fields: any valid JSON value that was stored, or `null` if the key does not exist
 
 !!! info ""
     Write the storage value for the specified key; the data must be valid JSON, maximum 1MB
 
 - Request method: `PUT`
 - Data: `'{"foo": "bar"}'`
+- Response: none (HTTP 204)
 
 !!! info ""
     Delete the storage value for the specified key
 
 - Request method: `DELETE`
+- Response: none (HTTP 204)
 
 ## DEBUG
 
@@ -336,6 +448,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Perform active garbage collection
 
 - Request method: `PUT`
+- Response: none (HTTP 204)
 
 ### `/debug/pprof`
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,7 +44,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 ### `/traffic`
 
 !!! info ""
-    获取实时流量，单位 kbps
+    获取实时流量，`up`/`down` 单位为字节/秒，`upTotal`/`downTotal` 单位为字节
 
 - 请求方法：`GET` / `WS`
 - 返回字段（每秒推送一次）：
@@ -58,7 +58,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 ### `/memory`
 
 !!! info ""
-    获取实时内存占用，单位 kb
+    获取实时内存占用，单位为字节
 
 - 请求方法：`GET` / `WS`
 - 返回字段（每秒推送一次）：

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,6 +30,14 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 - 请求方法：`GET` / `WS`
 - 可选参数：`?level=log_level`, 其中 `log_level` 可选值为 `info`, `warning`, `error`, `debug`
 - 可选参数：`?format=structured`, 携带后输出结构化日志（包含 `time`、`level`、`message`、`fields` 字段）
+- 返回字段（标准模式，每行推送一个 JSON）：
+    - `type`：日志级别，可选值 `info` / `warning` / `error` / `debug`
+    - `payload`：日志内容
+- 返回字段（结构化模式 `?format=structured`）：
+    - `time`：时间字符串（格式 `HH:MM:SS`）
+    - `level`：日志级别
+    - `message`：日志内容
+    - `fields`：附加字段数组
 
 ## 流量信息
 
@@ -39,6 +47,11 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取实时流量，单位 kbps
 
 - 请求方法：`GET` / `WS`
+- 返回字段（每秒推送一次）：
+    - `up`：当前上传速率（字节/秒）
+    - `down`：当前下载速率（字节/秒）
+    - `upTotal`：累计上传字节数
+    - `downTotal`：累计下载字节数
 
 ## 内存信息
 
@@ -48,6 +61,9 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取实时内存占用，单位 kb
 
 - 请求方法：`GET` / `WS`
+- 返回字段（每秒推送一次）：
+    - `inuse`：当前内存使用量（字节）
+    - `oslimit`：系统内存限制（字节，固定为 `0`）
 
 ## 版本信息
 
@@ -57,6 +73,9 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取 mihomo 版本信息
 
 - 请求方法：`GET`
+- 返回字段：
+    - `meta`：是否为 Meta 版本（`true` / `false`）
+    - `version`：版本号字符串
 
 ## 缓存
 
@@ -66,6 +85,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     清除 fakeip 缓存
 
 - 请求方法：`POST`
+- 返回：无（HTTP 204）
 
 ### `/cache/dns/flush`
 
@@ -73,6 +93,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     清除 dns 缓存
 
 - 请求方法：`POST`
+- 返回：无（HTTP 204）
 
 ## 运行配置
 
@@ -82,18 +103,21 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取基本配置
 
 - 请求方法：`GET`
+- 返回字段：当前运行配置的 JSON 对象，包含 `port`、`socks-port`、`mixed-port`、`mode`、`log-level`、`allow-lan`、`ipv6`、`tun` 等字段
 
 !!! info ""
     重新加载基本配置
 
 - 请求方法：`PUT`
 - 携带参数：`?force=true`
+- 返回：无（HTTP 204）
 
 !!! info ""
     更新基本配置
 
 - 请求方法：`PATCH`
 - 携带数据：`'{"mixed-port": 7890}'`
+- 返回：无（HTTP 204）
 
 ### `/configs/geo`
 
@@ -102,6 +126,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`POST`
 - 发送数据：`'{"path": "", "payload": ""}'`
+- 返回：无（HTTP 204）
 
 ### `/restart`
 
@@ -110,6 +135,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`POST`
 - 发送数据：`'{"path": "", "payload": ""}'`
+- 返回：无（HTTP 204）
 
 ## 更新
 
@@ -121,6 +147,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 - 请求方法：`POST`
 - 可选参数：`?channel=xxx` 指定更新通道，`?force=true` 强制更新
 - 发送数据：`'{"path": "", "payload": ""}'`
+- 返回字段：
+    - `status`：固定为 `"ok"`
 
 ### `/upgrade/ui`
 
@@ -128,6 +156,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     更新面板，须设置 [external-ui](../config/general.md#_7)
 
 - 请求方法：`POST`
+- 返回字段：
+    - `status`：固定为 `"ok"`
 
 ### `/upgrade/geo`
 
@@ -136,6 +166,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`POST`
 - 发送数据：`'{"path": "", "payload": ""}'`
+- 返回：无（HTTP 204）
 
 ## 策略组
 
@@ -145,6 +176,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取策略组信息
 
 - 请求方法：`GET`
+- 返回字段：
+    - `proxies`：策略组对象数组，每个对象格式同 `/proxies/proxies_name`
 
 ### `/group/group_name`
 
@@ -152,6 +185,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取具体的策略组信息
 
 - 请求方法：`GET`
+- 返回字段：策略组对象，格式同 `/proxies/proxies_name`
 
 ### `/group/group_name/delay`
 
@@ -161,6 +195,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 - 请求方法：`GET`
 - 携带参数：`?url=xxx&timeout=5000`
 - 可选参数：`?expected=xxx`, 期望的 HTTP 响应状态码，支持范围写法（如 `200/204`、`200-299`）
+- 返回字段：以节点名称为键、延迟毫秒数（`uint16`）为值的 JSON 对象，例如 `{"节点A": 120, "节点B": 350}`
 
 ## 代理
 
@@ -170,6 +205,23 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取代理信息
 
 - 请求方法：`GET`
+- 返回字段：
+    - `proxies`：以代理名称为键的对象，每个代理包含以下字段：
+        - `name`：代理名称
+        - `type`：代理类型（如 `Shadowsocks`、`VMess`、`DIRECT`、`Selector` 等）
+        - `udp`：是否支持 UDP
+        - `uot`：是否支持 UDP over TCP
+        - `xudp`：是否支持 XUDP
+        - `tfo`：是否启用 TCP Fast Open
+        - `mptcp`：是否启用 MPTCP
+        - `smux`：是否启用多路复用
+        - `alive`：当前是否存活
+        - `history`：延迟历史数组，每项含 `time`（时间）和 `delay`（毫秒）
+        - `extra`：额外延迟历史（按测试 URL 分组）
+        - `interface`：绑定的网卡名称
+        - `routing-mark`：路由标记
+        - `provider-name`：所属代理集合名称
+        - `dialer-proxy`：底层拨号代理名称
 
 ### `/proxies/proxies_name`
 
@@ -177,17 +229,20 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取具体的代理信息
 
 - 请求方法：`GET`
+- 返回字段：代理对象，字段同 `/proxies` 中的单个代理条目
 
 !!! info ""
     选择特定的代理
 
 - 请求方法：`PUT`
 - 携带数据：`'{"name":"日本"}'`
+- 返回：无（HTTP 204）
 
 !!! info ""
     清除该代理/策略组的 fixed 固定选择（`Selector` 类型除外）
 
 - 请求方法：`DELETE`
+- 返回：无（HTTP 204）
 
 ### `/proxies/proxies_name/delay`
 
@@ -197,6 +252,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 - 请求方法：`GET`
 - 携带参数：`?url=xxx&timeout=5000`
 - 可选参数：`?expected=xxx`, 期望的 HTTP 响应状态码，支持范围写法（如 `200/204`、`200-299`）
+- 返回字段：
+    - `delay`：测试延迟（毫秒，`uint16`）
 
 ## 代理集合
 
@@ -206,6 +263,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取所有代理集合的所有信息
 
 - 请求方法：`GET`
+- 返回字段：
+    - `providers`：以集合名称为键的对象，每个集合包含其元信息及代理列表
 
 ### `/providers/proxies/providers_name`
 
@@ -213,11 +272,13 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取特定代理集合的信息
 
 - 请求方法：`GET`
+- 返回字段：代理集合对象，包含集合配置信息及 `proxies` 代理列表
 
 !!! info ""
     更新代理集合
 
 - 请求方法：`PUT`
+- 返回：无（HTTP 204）
 
 ### `/providers/proxies/providers_name/healthcheck`
 
@@ -225,6 +286,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     触发特定代理集合的健康检查
 
 - 请求方法：`GET`
+- 返回：无（HTTP 204）
 
 ### `/providers/proxies/providers_name/proxies_name`
 
@@ -232,6 +294,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取代理集合内指定代理的信息
 
 - 请求方法：`GET`
+- 返回字段：代理对象，字段同 `/proxies/proxies_name`
 
 ### `/providers/proxies/providers_name/proxies_name/healthcheck`
 
@@ -240,6 +303,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`GET`
 - 携带参数：`?url=xxx&timeout=5000`
+- 返回字段：
+    - `delay`：测试延迟（毫秒，`uint16`）
 
 ## 规则
 
@@ -249,6 +314,19 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取规则信息
 
 - 请求方法：`GET`
+- 返回字段：
+    - `rules`：规则数组，每个元素包含：
+        - `index`：规则索引（从 0 开始）
+        - `type`：规则类型（如 `DOMAIN`、`IP-CIDR`、`GEOIP` 等）
+        - `payload`：规则匹配内容
+        - `proxy`：目标代理/策略组名称
+        - `size`：规则条目数量（仅 `GEOIP` / `GEOSITE` 类型有效，其他为 `-1`）
+        - `extra`（可选，存在时包含以下字段）：
+            - `disabled`：是否已禁用
+            - `hitCount`：命中次数
+            - `hitAt`：最后命中时间
+            - `missCount`：未命中次数
+            - `missAt`：最后未命中时间
 
 ### `/rules/disable`
 
@@ -257,6 +335,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`PATCH`
 - 携带数据：`'{"0": false,"1": true}'`
+- 返回：无（HTTP 204）
 
 ## 规则集合
 
@@ -266,6 +345,8 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取所有规则集合的所有信息
 
 - 请求方法：`GET`
+- 返回字段：
+    - `providers`：以规则集合名称为键的对象
 
 ### `/providers/rules/providers_name`
 
@@ -273,6 +354,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     更新规则集合
 
 - 请求方法：`PUT`
+- 返回：无（HTTP 204）
 
 ## 连接
 
@@ -283,11 +365,26 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`GET` / `WS`
 - 可选参数：`?interval=milliseconds`, 其中 `milliseconds` 为刷新间隔，默认值为 1000 毫秒
+- 返回字段：
+    - `downloadTotal`：累计下载字节数
+    - `uploadTotal`：累计上传字节数
+    - `memory`：当前内存使用量（字节）
+    - `connections`：活跃连接数组，每项包含：
+        - `id`：连接唯一 ID
+        - `metadata`：连接元数据（源/目标地址、协议、进程名称等）
+        - `upload`：该连接已上传字节数
+        - `download`：该连接已下载字节数
+        - `start`：连接建立时间
+        - `chains`：代理链路数组
+        - `providerChains`：provider 代理链路数组
+        - `rule`：命中规则类型
+        - `rulePayload`：命中规则内容
 
 !!! info ""
     关闭所有连接
 
 - 请求方法：`DELETE`
+- 返回：无（HTTP 204）
 
 ### `/connections/:id`
 
@@ -295,6 +392,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     关闭特定连接
 
 - 请求方法：`DELETE`
+- 返回：无（HTTP 204）
 
 ## 域名查询
 
@@ -305,6 +403,17 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`GET`
 - 携带参数：`?name=example.com&type=A`
+- 返回字段：
+    - `Status`：DNS 响应码（Rcode）
+    - `Question`：查询问题数组
+    - `TC`：是否截断（Truncated）
+    - `RD`：是否期望递归（RecursionDesired）
+    - `RA`：是否支持递归（RecursionAvailable）
+    - `AD`：数据是否已认证（AuthenticatedData）
+    - `CD`：是否禁止检查（CheckingDisabled）
+    - `Answer`（可选）：答案记录数组，每项含 `name`、`type`、`TTL`、`data`
+    - `Authority`（可选）：权威记录数组，格式同 `Answer`
+    - `Additional`（可选）：附加记录数组，格式同 `Answer`
 
 ## 存储
 
@@ -314,17 +423,20 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取指定 key 的存储值，不存在时返回 `null`
 
 - 请求方法：`GET`
+- 返回字段：存储的任意合法 JSON 值，不存在时返回 `null`
 
 !!! info ""
     写入指定 key 的存储值，数据须为合法 JSON，最大 1MB
 
 - 请求方法：`PUT`
 - 携带数据：`'{"foo": "bar"}'`
+- 返回：无（HTTP 204）
 
 !!! info ""
     删除指定 key 的存储值
 
 - 请求方法：`DELETE`
+- 返回：无（HTTP 204）
 
 ## DEBUG
 
@@ -336,6 +448,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     进行主动 GC
 
 - 请求方法：`PUT`
+- 返回：无（HTTP 204）
 
 ### `/debug/pprof`
 


### PR DESCRIPTION
## Summary

- Add `- 返回字段` / `- Response fields` bullet points to every API endpoint in `docs/api/index.md` and `docs/api/index.en.md`
- Endpoints that return JSON data now list all response field names, types, and brief descriptions
- Endpoints that return HTTP 204 No Content are now explicitly marked as `返回：无（HTTP 204）` / `Response: none (HTTP 204)`

All response structures were derived directly from the mihomo source code under `hub/route/`, so the documented fields match the actual implementation.

## Endpoints documented

| Endpoint | Response |
|---|---|
| `/logs` | `type`, `payload` (standard); `time`, `level`, `message`, `fields` (structured) |
| `/traffic` | `up`, `down`, `upTotal`, `downTotal` |
| `/memory` | `inuse`, `oslimit` |
| `/version` | `meta`, `version` |
| `/configs` GET | full config JSON object |
| `/upgrade`, `/upgrade/ui` | `status: "ok"` |
| `/group`, `/group/:name` | proxy group object |
| `/group/:name/delay` | map of `{node: delay_ms}` |
| `/proxies` | 14 fields per proxy entry |
| `/proxies/:name/delay`, `/providers/.../healthcheck` | `delay` |
| `/rules` | `index`, `type`, `payload`, `proxy`, `size`, `extra` |
| `/providers/rules`, `/providers/proxies` | `providers` map |
| `/connections` | `downloadTotal`, `uploadTotal`, `memory`, `connections` array (9 fields each) |
| `/dns/query` | `Status`, `Question`, `TC`, `RD`, `RA`, `AD`, `CD`, `Answer`, `Authority`, `Additional` |
| `/storage/:key` GET | stored JSON value or `null` |

## Test plan

- [ ] Verify rendered docs look correct on the MkDocs site
- [ ] Spot-check a few fields against live mihomo API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)