### PR TITLE
docs(api): document policy group fields in /proxies response

### DIFF
--- a/docs/api/index.en.md
+++ b/docs/api/index.en.md
@@ -206,9 +206,9 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
 
 - Request method: `GET`
 - Response fields:
-    - `proxies`: object keyed by proxy name; each proxy contains:
-        - `name`: proxy name
-        - `type`: proxy type (e.g. `Shadowsocks`, `VMess`, `DIRECT`, `Selector`, etc.)
+    - `proxies`: object keyed by proxy/group name; every entry shares these **common fields**:
+        - `name`: proxy or group name
+        - `type`: type (e.g. `Shadowsocks`, `VMess`, `DIRECT`, `Selector`, `URLTest`, `Fallback`, `LoadBalance`, etc.)
         - `udp`: whether UDP is supported
         - `uot`: whether UDP over TCP is supported
         - `xudp`: whether XUDP is supported
@@ -222,6 +222,15 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
         - `routing-mark`: routing mark value
         - `provider-name`: name of the proxy provider this proxy belongs to
         - `dialer-proxy`: underlying dialer proxy name
+    - **Policy groups** (`Selector`, `URLTest`, `Fallback`, `LoadBalance`) additionally include:
+        - `now`: currently selected node name (absent for `LoadBalance`)
+        - `all`: array of all node/group names in the group
+        - `testUrl`: health check URL
+        - `hidden`: whether the group is hidden in the dashboard
+        - `icon`: icon URL
+        - `emptyFallback`: fallback node name used when all members are unavailable
+        - `expectedStatus`: expected HTTP response status code for health checks (absent for `Selector`)
+        - `fixed`: currently pinned node name (only `URLTest` and `Fallback`)
 
 ### `/proxies/proxies_name`
 
@@ -229,7 +238,7 @@ This request includes the header `'Authorization: Bearer ${secret}'`, where:
     Retrieve specific proxy information
 
 - Request method: `GET`
-- Response fields: proxy object, same fields as a single entry under `/proxies`
+- Response fields: proxy or group object, same fields as a single entry under `/proxies` (regular proxies have only the common fields; policy groups additionally include `now`, `all`, etc.)
 
 !!! info ""
     Select a specific proxy

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -206,9 +206,9 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`GET`
 - 返回字段：
-    - `proxies`：以代理名称为键的对象，每个代理包含以下字段：
-        - `name`：代理名称
-        - `type`：代理类型（如 `Shadowsocks`、`VMess`、`DIRECT`、`Selector` 等）
+    - `proxies`：以代理名称为键的对象，每个条目均包含以下**公共字段**：
+        - `name`：代理/策略组名称
+        - `type`：类型（如 `Shadowsocks`、`VMess`、`DIRECT`、`Selector`、`URLTest`、`Fallback`、`LoadBalance` 等）
         - `udp`：是否支持 UDP
         - `uot`：是否支持 UDP over TCP
         - `xudp`：是否支持 XUDP
@@ -222,6 +222,15 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
         - `routing-mark`：路由标记
         - `provider-name`：所属代理集合名称
         - `dialer-proxy`：底层拨号代理名称
+    - 对于**策略组**（`Selector`、`URLTest`、`Fallback`、`LoadBalance`），还额外包含：
+        - `now`：当前选中的节点名称（`LoadBalance` 无此字段）
+        - `all`：组内所有节点/策略组名称数组
+        - `testUrl`：健康检查 URL
+        - `hidden`：是否在面板中隐藏
+        - `icon`：图标 URL
+        - `emptyFallback`：成员全部不可用时的兜底节点名称
+        - `expectedStatus`：期望的 HTTP 响应状态码（`Selector` 无此字段）
+        - `fixed`：当前固定选中的节点名称（仅 `URLTest`、`Fallback`）
 
 ### `/proxies/proxies_name`
 
@@ -229,7 +238,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
     获取具体的代理信息
 
 - 请求方法：`GET`
-- 返回字段：代理对象，字段同 `/proxies` 中的单个代理条目
+- 返回字段：代理或策略组对象，字段同 `/proxies` 中的单个条目（普通代理仅含公共字段，策略组另含 `now`、`all` 等字段）
 
 !!! info ""
     选择特定的代理

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -206,7 +206,7 @@ curl 示例 `curl -H 'Authorization: Bearer ${secret}'  http://${controller-api}
 
 - 请求方法：`GET`
 - 返回字段：
-    - `proxies`：以代理名称为键的对象，每个条目均包含以下**公共字段**：
+    - `proxies`：以代理/策略组名称为键的对象，每个条目均包含以下**公共字段**：
         - `name`：代理/策略组名称
         - `type`：类型（如 `Shadowsocks`、`VMess`、`DIRECT`、`Selector`、`URLTest`、`Fallback`、`LoadBalance` 等）
         - `udp`：是否支持 UDP


### PR DESCRIPTION
## Summary

- The `/proxies` endpoint returns **both** individual proxies and policy groups, but the previous documentation only listed the fields common to individual proxies.
- Add documentation for the group-specific fields that appear when the entry is a `Selector`, `URLTest`, `Fallback`, or `LoadBalance` group.
- Clarify `/proxies/proxies_name` response to note the distinction between regular proxies and policy groups.

## What changed

**Common fields** (all entries):
`name`, `type`, `udp`, `uot`, `xudp`, `tfo`, `mptcp`, `smux`, `alive`, `history`, `extra`, `interface`, `routing-mark`, `provider-name`, `dialer-proxy`

**Policy group additional fields** (`Selector` / `URLTest` / `Fallback` / `LoadBalance`):

| Field | Present in |
|---|---|
| `now` | `Selector`, `URLTest`, `Fallback` |
| `all` | all groups |
| `testUrl` | all groups |
| `hidden` | all groups |
| `icon` | all groups |
| `emptyFallback` | all groups |
| `expectedStatus` | `URLTest`, `Fallback`, `LoadBalance` |
| `fixed` | `URLTest`, `Fallback` |

Sourced from `adapter/outboundgroup/{selector,urltest,fallback,loadbalance}.go` `MarshalJSON` methods.

## Test plan

- [ ] Verify rendered docs look correct on the MkDocs site
- [ ] Spot-check group fields against a live `/proxies` API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)