### PR TITLE
Update client.md

### DIFF
--- a/docs/startup/client/client.en.md
+++ b/docs/startup/client/client.en.md
@@ -26,7 +26,6 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|Maintained |
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|Maintained |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|Maintained |
-|[ClashPlus](https://clashplus.io)|Maintained | Closed-source |
 
 ## MacOS
 
@@ -50,7 +49,6 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|Maintained |
 |[KumoApp](https://github.com/ProjectKumo/KumoApp)|Maintained |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|Maintained |
-|[ClashPlus](https://clashplus.io)|Maintained | Closed-source |
 |[Rabbit Hole](https://apps.apple.com/us/app/rabbithole-vpn-client/id6683309629)|Maintained | Closed-source |
 
 ## Linux
@@ -73,7 +71,7 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|Maintained |
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|Maintained |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|Maintained |
-|[ClashMi](https://github.com/KaringX/clashmi)|Maintained | Frontend is open-source |
+|[ClashMi](https://github.com/KaringX/clashmi)|Maintained | Frontend is open-source;build is not reproducible |
 
 ## Android
 
@@ -90,7 +88,6 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[ClashFest](https://github.com/Nemu-x/ClashFest)|Maintained |
 |[AsteriskMETA](https://github.com/Asterisk4Magisk/AsteriskMETA)|Maintained |
 |[SlClash](https://github.com/songzhengpei/Slclash)|Maintained |
-|[ClashPlus](https://clashplus.io)|Maintained | Closed-source |
 
 ## iOS
 
@@ -102,7 +99,6 @@ The tools/clients listed here use or include the mihomo core. We **do not direct
 |[ConnectNow](https://apps.apple.com/app/id6749354119)|Maintained | Closed-source |
 |[Everywhere](https://github.com/NodePassProject/Everywhere)|Maintained |
 |[Nextin](https://apps.apple.com/app/id6754002454)|Maintained | Closed-source |
-|[ClashPlus](https://apps.apple.com/app/id6774378761)|Maintained | Closed-source |
 |[Rabbit Hole](https://apps.apple.com/us/app/rabbithole-vpn-client/id6683309629)|Maintained | Closed-source |
 
 ## Merlin (KoolCenter firmware/paldier SWRT firmware)

--- a/docs/startup/client/client.md
+++ b/docs/startup/client/client.md
@@ -26,7 +26,6 @@
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|维护中 |
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|维护中 |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|维护中 |
-|[ClashPlus](https://clashplus.io)|维护中 |不开源  |
 
 ## MacOS
 
@@ -51,7 +50,6 @@
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|维护中 |
 |[KumoApp](https://github.com/ProjectKumo/KumoApp)|维护中 |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|维护中 |
-|[ClashPlus](https://clashplus.io)|维护中 |不开源  |
 |[Rabbit Hole](https://apps.apple.com/us/app/rabbithole-vpn-client/id6683309629)|维护中 | 不开源 |
 
 ## Linux
@@ -90,7 +88,6 @@
 |[ClashFest](https://github.com/Nemu-x/ClashFest)|维护中 |
 |[AsteriskMETA](https://github.com/Asterisk4Magisk/AsteriskMETA)|维护中 |
 |[SlClash](https://github.com/songzhengpei/Slclash)|维护中 |
-|[ClashPlus](https://clashplus.io)|维护中 |不开源  |
 
 ## iOS
 
@@ -102,7 +99,6 @@
 |[ConnectNow](https://apps.apple.com/app/id6749354119)|维护中 | 不开源 |
 |[Everywhere](https://github.com/NodePassProject/Everywhere)|维护中 |
 |[Nextin](https://apps.apple.com/app/id6754002454)|维护中 | 不开源 |
-|[ClashPlus](https://apps.apple.com/app/id6774378761)|维护中 | 不开源 |
 |[Rabbit Hole](https://apps.apple.com/us/app/rabbithole-vpn-client/id6683309629)|维护中 | 不开源 |
 
 ## Merlin (KoolCenter 固件/paldier SWRT 固件)

--- a/docs/startup/client/client.md
+++ b/docs/startup/client/client.md
@@ -72,6 +72,7 @@
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|维护中 |
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|维护中 |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|维护中 |
+|[ClashMi](https://github.com/KaringX/clashmi)|维护中 | 前端开源，构建不可复现 |
 
 ## Android
 

--- a/docs/startup/client/client.ru.md
+++ b/docs/startup/client/client.ru.md
@@ -25,8 +25,7 @@
 |[GoclashZ](https://github.com/Zzz-IT/GoclashZ)|поддерживается |
 |[Zephyr](https://github.com/Juwan-Hwang/Zephyr)|поддерживается |
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|поддерживается |
-|[Flowvy](https://github.com/flowvy-proxy/desktop)|поддерживается |
-|[ClashPlus](https://clashplus.io)|поддерживается |Закрытый исходный код  |
+|[Flowvy](https://github.com/flowvy-proxy/desktop)|поддерживается 丨
 
 ## MacOS
 
@@ -50,7 +49,6 @@
 |[SlothClash](https://github.com/Nemu-x/SlothClash)|поддерживается |
 |[KumoApp](https://github.com/ProjectKumo/KumoApp)|поддерживается |
 |[Flowvy](https://github.com/flowvy-proxy/desktop)|поддерживается |
-|[ClashPlus](https://clashplus.io)|поддерживается |Закрытый исходный код  |
 |[Rabbit Hole](https://apps.apple.com/us/app/rabbithole-vpn-client/id6683309629)|поддерживается |Закрытый исходный код  |
 
 ## Linux
@@ -90,7 +88,6 @@
 |[ClashFest](https://github.com/Nemu-x/ClashFest)|поддерживается |
 |[AsteriskMETA](https://github.com/Asterisk4Magisk/AsteriskMETA)|поддерживается |
 |[SlClash](https://github.com/songzhengpei/Slclash)|поддерживается |
-|[ClashPlus](https://clashplus.io)|поддерживается |Закрытый исходный код  |
 
 ## iOS
 
@@ -102,7 +99,6 @@
 |[ConnectNow](https://apps.apple.com/app/id6749354119)|поддерживается | Закрытый исходный код |
 |[Everywhere](https://github.com/NodePassProject/Everywhere)|поддерживается |
 |[Nextin](https://apps.apple.com/app/id6754002454)|поддерживается | Закрытый исходный код |
-|[ClashPlus](https://clashplus.io)|поддерживается |Закрытый исходный код  |
 |[Rabbit Hole](https://apps.apple.com/us/app/rabbithole-vpn-client/id6683309629)|поддерживается |Закрытый исходный код  |
 
 ## Merlin (прошивка KoolCenter/paldier SWRT)


### PR DESCRIPTION
删除Clash Plus，并且恢复Clash Mi 前端开源，不可构建 的描述